### PR TITLE
Feature #13 hide admin only menuitems

### DIFF
--- a/src/main/java/be/archilios/usermanagement/security/SecurityService.java
+++ b/src/main/java/be/archilios/usermanagement/security/SecurityService.java
@@ -22,6 +22,13 @@ public class SecurityService {
         return null;
     }
     
+    public boolean isAuthenticatedUserAdmin() {
+        UserDetails user = getAuthenticatedUser();
+        return user != null && user.getAuthorities().stream().anyMatch(
+                a -> a.getAuthority().equals("ROLE_ADMIN")
+        );
+    }
+    
     public void logout() {
         UI.getCurrent().getPage().setLocation(LOGOUT_SUCCES_URL);
         SecurityContextLogoutHandler logoutHandler = new SecurityContextLogoutHandler();

--- a/src/main/java/be/archilios/usermanagement/security/UseManPageNotFoundError.java
+++ b/src/main/java/be/archilios/usermanagement/security/UseManPageNotFoundError.java
@@ -1,0 +1,21 @@
+package be.archilios.usermanagement.security;
+
+import be.archilios.usermanagement.views.error.AccessDeniedView;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.NotFoundException;
+import com.vaadin.flow.router.RouteNotFoundError;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.Serial;
+
+public class UseManPageNotFoundError extends RouteNotFoundError {
+    @Serial
+    private static final long serialVersionUID = 21358157369L;
+    
+    @Override
+    public int setErrorParameter(final BeforeEnterEvent event, final ErrorParameter<NotFoundException> parameter) {
+        event.forwardTo(AccessDeniedView.class);
+        return HttpServletResponse.SC_NOT_FOUND;
+    }
+}

--- a/src/main/java/be/archilios/usermanagement/views/MainLayout.java
+++ b/src/main/java/be/archilios/usermanagement/views/MainLayout.java
@@ -69,15 +69,31 @@ public class MainLayout extends AppLayout {
         appName.addClassNames(LumoUtility.FontSize.LARGE, LumoUtility.Margin.NONE);
         Header header = new Header(appName);
 
-        Scroller scroller = new Scroller(createNavigation());
+        Scroller userScroller = new Scroller(createNavigation());
 
-        addToDrawer(header, scroller, createFooter());
+        addToDrawer(header, userScroller);
+        
+        if (security.isAuthenticatedUserAdmin()) {
+            Scroller adminScroller = new Scroller(createAdminNavigation());
+            addToDrawer(adminScroller);
+        }
+        
+        addToDrawer(createFooter());
     }
 
     private SideNav createNavigation() {
         SideNav nav = new SideNav();
 
         nav.addItem(new SideNavItem("Dashboard", DashboardView.class, LineAwesomeIcon.HOME_SOLID.create()));
+
+        return nav;
+    }
+    
+    private SideNav createAdminNavigation() {
+        SideNav nav = new SideNav();
+        nav.setLabel("Admin");
+        nav.setCollapsible(true);
+        
         nav.addItem(new SideNavItem("Users", UserManagementView.class, LineAwesomeIcon.USERS_COG_SOLID.create()));
 
         return nav;

--- a/src/main/java/be/archilios/usermanagement/views/MainLayout.java
+++ b/src/main/java/be/archilios/usermanagement/views/MainLayout.java
@@ -1,13 +1,17 @@
 package be.archilios.usermanagement.views;
 
+import be.archilios.usermanagement.security.SecurityService;
 import be.archilios.usermanagement.views.admin.users.UserManagementView;
 import be.archilios.usermanagement.views.dashboard.DashboardView;
 import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.component.applayout.DrawerToggle;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.html.Footer;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Header;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.Scroller;
 import com.vaadin.flow.component.sidenav.SideNav;
 import com.vaadin.flow.component.sidenav.SideNavItem;
@@ -15,14 +19,19 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.theme.lumo.LumoUtility;
 import org.vaadin.lineawesome.LineAwesomeIcon;
 
+import static java.util.Objects.nonNull;
+
 /**
  * The main view is a top-level placeholder for other views.
  */
 public class MainLayout extends AppLayout {
 
     private H2 viewTitle;
+    private final SecurityService security;
 
-    public MainLayout() {
+    public MainLayout(SecurityService security) {
+        this.security = security;
+        
         setPrimarySection(Section.DRAWER);
         addDrawerContent();
         addHeaderContent();
@@ -36,6 +45,23 @@ public class MainLayout extends AppLayout {
         viewTitle.addClassNames(LumoUtility.FontSize.LARGE, LumoUtility.Margin.NONE);
 
         addToNavbar(true, toggle, viewTitle);
+        
+        setLogoutButtonIfLogin();
+    }
+    
+    private void setLogoutButtonIfLogin() {
+        if (nonNull(security.getAuthenticatedUser())) {
+            Button logoutButton = new Button("Logout");
+            
+            logoutButton.addClickListener(e -> {
+                security.logout();
+            });
+            
+            logoutButton.setIcon(VaadinIcon.SIGN_OUT.create());
+            logoutButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+            logoutButton.getStyle().set("margin-left", "2rem");
+            addToNavbar(logoutButton);
+        }
     }
 
     private void addDrawerContent() {

--- a/src/main/java/be/archilios/usermanagement/views/error/AccessDeniedView.java
+++ b/src/main/java/be/archilios/usermanagement/views/error/AccessDeniedView.java
@@ -1,0 +1,29 @@
+package be.archilios.usermanagement.views.error;
+
+import be.archilios.usermanagement.views.MainLayout;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.PermitAll;
+
+@PageTitle("Oopss! Access Denied!")
+@Route(value = "error/400", layout = MainLayout.class)
+@PermitAll
+public class AccessDeniedView extends VerticalLayout {
+    public AccessDeniedView() {
+        addClassName("acces-denied-view");
+        setSizeFull();
+        H2 title = new H2("Oopss! Access Denied!");
+        H3 subTitle = new H3("You are not allowed to access this page!");
+        Div message = new Div();
+        message.setText("You are not allowed to access this page. Please contact the administrator if you think this is a mistake.");
+        
+        setHeightFull();
+        setAlignItems(Alignment.CENTER);
+        setHorizontalComponentAlignment(Alignment.CENTER, title, message);
+        add(title, subTitle, message);
+    }
+}

--- a/src/test/java/be/archilios/usermanagement/security/SecurityServiceTest.java
+++ b/src/test/java/be/archilios/usermanagement/security/SecurityServiceTest.java
@@ -1,0 +1,77 @@
+package be.archilios.usermanagement.security;
+
+import be.archilios.usermanagement.security.user.SecurityUserMother;
+import be.archilios.usermanagement.security.user.UserDetailsFromSecurityUser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SecurityServiceTest {
+    
+    private UserDetailsFromSecurityUser expectedUser = new UserDetailsFromSecurityUser(SecurityUserMother.get().build());
+    private UserDetailsFromSecurityUser expectedAdmin = new UserDetailsFromSecurityUser(SecurityUserMother.get().asAdmin().build());
+    @Mock
+    private Authentication auth;
+    @Mock
+    private SecurityContext secCtx;
+    @InjectMocks
+    private SecurityService securityService;
+    
+    @Test
+    void getAuthenticatedUser() {
+        // Arrange
+        when(auth.getPrincipal()).thenReturn(expectedUser);
+        when(secCtx.getAuthentication()).thenReturn(auth);
+        when(secCtx.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(secCtx);
+        
+        UserDetails result = securityService.getAuthenticatedUser();
+        
+        assertEquals(expectedUser, result);
+    }
+    
+    @Test
+    void throwExceptionWhenNoUserIsAuthenticated() {
+        // Arrange
+        when(secCtx.getAuthentication()).thenReturn(null);
+        SecurityContextHolder.setContext(secCtx);
+        
+        // Act & Assert
+        assertThrows(NullPointerException.class, () -> securityService.getAuthenticatedUser());
+    }
+    
+    @Test
+    void isAuthenticatedUserAdmin() {
+        // Arrange
+        when(auth.getPrincipal()).thenReturn(expectedAdmin);
+        when(secCtx.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(secCtx);
+        
+        boolean result = securityService.isAuthenticatedUserAdmin();
+        
+        assertTrue(result);
+    }
+    
+    @Test
+    void isAuthenticatedUserNotAdmin() {
+        // Arrange
+        when(auth.getPrincipal()).thenReturn(expectedUser);
+        when(secCtx.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(secCtx);
+        
+        boolean result = securityService.isAuthenticatedUserAdmin();
+        
+        assertFalse(result);
+    }
+    
+}


### PR DESCRIPTION
# Pull Request: #13 Hide admin-only functions

## Changes summary

I have added a logout button and an Admin section to the menu of the application.
The admin section should only be visable if you login with an admin.
All unauthorized visits are redirected to a 400 error page.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests
- [x] I have run the tests locally

## Checklist for a reviewer
- [ ] Pull the repository and branch locally and manually test the changes.
- [ ] Does the code follow the style guidelines of the project
- [ ] Are all tests passing
- [ ] Does the described functionality work as proposed for both the happy and unhappy paths